### PR TITLE
fix: shebang not compatible with some linux distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL=/bin/bash
+SHELL=/usr/bin/env bash
 
 BIN=bin/crawley
 SRC=./cmd/crawley


### PR DESCRIPTION
Some distros (such as nixOS) don't have a `/bin/bash`, or users might use a different bash than the system one (e.g. to get a more up-to-date version).

Replacing the occurrences of `/bin/bash` by `/usr/bin/env bash` would enable those use-cases. Would this be considered acceptable?

Thanks!

---

Further info: https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang/10383546#10383546
Similar issue: https://github.com/facebook/buck2/issues/319
